### PR TITLE
Enhanced security settings and better iptables handling

### DIFF
--- a/ctldap.example.config
+++ b/ctldap.example.config
@@ -13,9 +13,12 @@ ldap_user=root
 ldap_password=XXXXXXXXXXXXXXXXXXXX
 ; If set to true, treat ldap_password as a bcrypt hash and compare against it
 ;ldap_password_bcrypt=true
+; LDAP server ip to listen on, change it to 0.0.0.0 when external access required
+; When you use the iptables_port setting, the port forwarding is stil installed on the eth0 card
+ldap_ip=127.0.0.1
 ; LDAP server port
 ldap_port=1389
-; The ctldap.sh service script will try to read this and setup an iptables NAT rule from iptables_port to ldap_port if it is set
+; The ctldap.sh service script will try to read this and setup an iptables NAT rule on interface eth0 from iptables_port to ldap_port if it is set
 iptables_port=389
 ; LDAP base DN o=xxx, e.g. churchtools
 ldap_base_dn=churchtools

--- a/ctldap.js
+++ b/ctldap.js
@@ -573,6 +573,6 @@ ldap.SubstringFilter.prototype.matches = function (target, strictAttrCase) {
 
 
 // Start LDAP server
-server.listen(parseInt(config.ldap_port), function () {
+server.listen(parseInt(config.ldap_port), config.ldap_ip, function () {
   console.log('ChurchTools-LDAP-Wrapper listening @ %s', server.url);
 });

--- a/ctldap_raw.sh
+++ b/ctldap_raw.sh
@@ -39,7 +39,7 @@ start)
     else
         echo $PID > $PIDFILE
         echo "$DESC started"
-        DPORT=$( cat $CTLDAP/ctldap.config | grep -oP "(?<=iptables_port=)[1-9][0-9]+" | head -n1 )
+        DPORT=$( cat $CTLDAP/ctldap.config | grep -oP "(?<=^iptables_port=)\s*[1-9][0-9]+" | head -n1 )
         if [ -n "$DPORT" ]; then
             echo "Trying to create iptables NAT rules for port redirect..."
             TO_PORT=$( cat $CTLDAP/ctldap.config | grep -oP "(?<=ldap_port=)[1-9][0-9]+" | head -n1 )


### PR DESCRIPTION
With this patch the default is to only listen on the localhost interface (Or any IP you specify), so remote acces to the ldap server has to be enabled by the user, with all security implications this might bring.

The daemon start script no longer installs the port forwaring, when the corresponding line in commented out in the config file

Solves issues #17 and #18